### PR TITLE
add fix for 0.55 shortcode behavior; markdownify func

### DIFF
--- a/layouts/shortcodes/section.html
+++ b/layouts/shortcodes/section.html
@@ -1,3 +1,3 @@
 <section data-shortcode-section>
-{{ .Inner }}
+{{ .Inner | markdownify }}
 </section>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "hugo -b $URL -s exampleSite"
 publish = "exampleSite/public"
 
 [context.production.environment]
-HUGO_VERSION = "0.55"
+HUGO_VERSION = "0.55.4"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.55"
+HUGO_VERSION = "0.55.4"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "hugo -b $URL -s exampleSite"
 publish = "exampleSite/public"
 
 [context.production.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.55"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.53"
+HUGO_VERSION = "0.55"


### PR DESCRIPTION
Fix for #29 

Pipe `section` content through [markdownify](https://gohugo.io/functions/markdownify/) so vertical slides render properly.  See https://gohugo.io/news/0.55.0-relnotes#shortcodes-revised for more info.