### PR TITLE
Fix hugo 0.58 regression

### DIFF
--- a/layouts/_default/index.reveal.html
+++ b/layouts/_default/index.reveal.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
   {{ partial "reveal-hugo/slides" (slice .Page) }}
-  {{ partial "reveal-hugo/slides" (where .Data.Pages "Type" "home") }}
+  {{ partial "reveal-hugo/slides" (where .Site.RegularPages "Type" "home") }}
 {{ end }}

--- a/layouts/_default/list.reveal.html
+++ b/layouts/_default/list.reveal.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
   {{ partial "reveal-hugo/slides" (slice .Page) }}
-  {{ partial "reveal-hugo/slides" .Pages }}
+  {{ partial "reveal-hugo/slides" .Site.RegularPages }}
 {{ end }}


### PR DESCRIPTION
Fixes #49, by simply implementing a warning shown by hugo v0.57:
```
WARN 2019/09/03 13:18:24 In the next Hugo version (0.58.0) we will change how
$home.Pages behaves. If you want to list all regular pages, replace .Pages or
.Data.Pages with .Site.RegularPages in your home page template
```