### PR TITLE
Add option to prevent loading default plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ Customize the Reveal.js presentation by setting these values in `config.toml` or
 - `reveal_hugo.highlight_theme`: The [highlight.js](https://highlightjs.org/) theme used; defaults to "default"
 - `reveal_hugo.reveal_cdn`: The location to load Reveal.js files from; defaults to the `reveal-js` folder in the static directory to support offline development. To load from a CDN instead, set this value to `https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.7.0` or whatever CDN you prefer.
 - `reveal_hugo.highlight_cdn`: The location to load highlight.js files from; defaults to to the `highlight-js` folder in the static directory to support offline development. To load from a CDN instead, set this value to `https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0` or whatever CDN you prefer.
-- `reveal_hugo.plugins`: An array of additional Reveal.js plugins to load, e.g. `["plugin/gallery/gallery.plugin.js"]`. The appropriate files will need to have been copied into the `static` directory. CDN loading is not supported. The plugins included by default are markdown, highlight.js, notes and zoom. See here for a [big list of plugins](https://github.com/hakimel/reveal.js/wiki/Plugins,-Tools-and-Hardware) you can try.
+- `reveal_hugo.load_default_plugins`: If set to true (default), the plugins included by default are loaded. These are markdown, highlight.js, notes and zoom.
+- `reveal_hugo.plugins`: An array of additional Reveal.js plugins to load, e.g. `["plugin/gallery/gallery.plugin.js"]`. The appropriate files will need to have been copied into the `static` directory. CDN loading is not supported. See here for a [big list of plugins](https://github.com/hakimel/reveal.js/wiki/Plugins,-Tools-and-Hardware) you can try.
 
 This is how parameters will look in your `config.toml`:
 

--- a/layouts/partials/layout/javascript.html
+++ b/layouts/partials/layout/javascript.html
@@ -47,12 +47,14 @@
 </script>
 <!-- load Reveal.js plugins after Reveal.js is initialized -->
 <script type="text/javascript" src="{{ printf "%s/lib/js/classList.js" $reveal_location | relURL }}"></script>
-{{ $default_plugins := slice "plugin/markdown/marked.js" "plugin/markdown/markdown.js" "plugin/highlight/highlight.js" "plugin/zoom-js/zoom.js" }}
-{{ range $default_plugins }}
-<script type="text/javascript" src="{{ printf "%s/%s" $reveal_location . | relURL }}"></script>
+{{ if $.Param "reveal_hugo.load_default_plugins" | default true }}
+  {{ $default_plugins := slice "plugin/markdown/marked.js" "plugin/markdown/markdown.js" "plugin/highlight/highlight.js" "plugin/zoom-js/zoom.js" }}
+  {{ range $default_plugins }}
+  <script type="text/javascript" src="{{ printf "%s/%s" $reveal_location . | relURL }}"></script>
+  {{ end }}
+  <!-- always use local version of the notes plugin since HTML file it requires isn't on CDN -->
+  <script type="text/javascript" src="{{ "reveal-js/plugin/notes/notes.js" | relURL }}"></script>
 {{ end }}
-<!-- always use local version of the notes plugin since HTML file it requires isn't on CDN -->
-<script type="text/javascript" src="{{ "reveal-js/plugin/notes/notes.js" | relURL }}"></script>
 <!-- load custom plugins locally only (not CDN since many plugins won't exist there) -->
 {{ range $.Param "reveal_hugo.plugins" }}
 <script type="text/javascript" src="{{ . | relURL }}"></script>

--- a/layouts/partials/layout/theme.html
+++ b/layouts/partials/layout/theme.html
@@ -16,6 +16,8 @@
   {{- $theme := $.Param "reveal_hugo.theme" | default "black" -}}
   <link rel="stylesheet" href="{{ printf "%s/css/theme/%s.css" $reveal_location $theme | relURL }}" id="theme">
 {{ end -}}
-<!-- Theme used for syntax highlighting of code -->
-{{- $highlight_theme := $.Param "reveal_hugo.highlight_theme" | default "default" -}}
-<link rel="stylesheet" href="{{ printf "%s/%s.min.css" $highlight_location $highlight_theme | relURL }}">
+{{ if $.Param "reveal_hugo.load_default_plugins" | default true -}}
+  <!-- Theme used for syntax highlighting of code -->
+  {{- $highlight_theme := $.Param "reveal_hugo.highlight_theme" | default "default" -}}
+  <link rel="stylesheet" href="{{ printf "%s/%s.min.css" $highlight_location $highlight_theme | relURL }}">
+{{- end }}


### PR DESCRIPTION
This PR adds a simple option `reveal_hugo.load_default_plugins` (default true) that controls the loading of default plugins (markdown, highlight.js, notes and zoom). If set to false the user is responsible for loading all plugins via `reveal_hugo.plugins` or any other means.

Some example use-cases (I'm sure there are others):
- disable highlight.js to use hugo's native compile-time highlighter (faster loading times)
- load notes.js from a locally installed copy of reveal.js (eg. to use the latest v3.8.0). When loaded as a default plugin, notes.js is always loaded from reveal-hugo's copy (apparently because notes.html does not exist in the CDN).

PS. the use of hugo's compile-time highlighter can be mentioned in the README, it's a super nice feature, as simple as:
```
pygmentsCodefences = true
# pygmentsCodefencesGuessSyntax = true
# pygmentsStyle = "..."

[params.reveal_hugo]
# load plugins manually, excluding highlight.js
plugins = [ "reveal-js/plugin/markdown/marked.js", "reveal-js/plugin/markdown/markdown.js", "reveal-js/plugin/zoom-js/zoom.js", "reveal-js/plugin/notes/notes.js" ]
load_default_plugins = false
```



