### PR TITLE
Allow markdown in note shortcodes (fixes #40)

### DIFF
--- a/exampleSite/content/home/shortcodes/other.md
+++ b/exampleSite/content/home/shortcodes/other.md
@@ -4,20 +4,20 @@ weight = 38
 
 ## Notes
 
-Add speaker notes to your presentation with the `note` shortcode. Type 's' to see this slide's speaker notes.
+Add speaker notes (with markdown) to your presentation with the `note` shortcode. Type 's' to see this slide's speaker notes.
 
 ```markdown
 ---
 
 {{%/* note */%}}
-You found the speaker notes!
+- You found the **speaker notes**!
 {{%/* /note */%}}
 
 ---
 ```
 
 {{% note %}}
-You found the speaker notes!
+- You found the **speaker notes**!
 {{% /note %}}
 
 ---

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,1 +1,4 @@
+{{/* Markdown is not rendered inside <aside> tags! So we use the following      */}}
+{{/* config which causes .Inner to be rendered before processing the shortcode. */}}
+{{ $_hugo_config := `{ "version": 1 }` }}
 <aside class="notes">{{ .Inner }}</aside>


### PR DESCRIPTION
Markdown is not rendered inside `<aside>`, so we need to [render the content before processing the shortcode](https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown), which is done by
```
{{ $_hugo_config := `{ "version": 1 }` }}
```