### PR TITLE
Add settings to extend CSS and JS from configuration

### DIFF
--- a/exampleSite/content/extending-layout-example/_index.md
+++ b/exampleSite/content/extending-layout-example/_index.md
@@ -1,0 +1,53 @@
++++
+title = "Extend layout with configuration"
+outputs = ["Reveal"]
+[reveal_hugo]
+theme = "night"
+margin = 0.2
+custom_css = "css/custom.css"
+custom_js = "js/custom.js"
++++
+
+### Extending an existing layout
+
+If you are using an existing theme and you want to a specific CSS class or add a dynamic function using javascript. It is possible to extend existing layout.
+
+---
+
+### Extending CSS
+
+You can use `partials` or you can specify `custom_css` in your configuration :
+
+```toml
+[reveal_hugo]
+custom_css = "css/custom.css"
+```
+<small>
+The `custom.css` can be present in `static/css/custom.css`
+</small>
+
+---
+
+### Extending with javascript
+
+Same as CSS you can extend your presentation with javascript using `partials` or with `custom_js` in your configuration:
+
+```toml
+[reveal_hugo]
+custom_js = "js/custom.js"
+```
+
+<small>
+The `custom.js` can be present in `static/js/custom.js`
+</small>
+
+---
+
+{{< slide class="custom" id="customjs" >}}
+## Extend layout example
+Here the slide has an additional css class `custom` using `slide` *shortcode*. This class is hosted in a custom CSS.
+
+If you click on this text background-color will using a custom javascript file. 
+
+
+

--- a/exampleSite/content/home/configuration.md
+++ b/exampleSite/content/home/configuration.md
@@ -140,3 +140,22 @@ Reveal.addEventListener('slidechanged', function(event) {
 });
 </script>
 ```
+
+---
+
+### Extending the layout 
+#### (alternative)
+
+You can declare a custom CSS or javascript in your configuration.
+
+```toml
+[reveal_hugo]
+custom_css = "css/custom.css"
+custom_js = "js/custom.js"
+```
+
+<small>
+These files can be located in `static/css`, `static/js` folder 
+
+💡 See the [extending layout example](/extending-layout-example/#) for more details.
+</small>

--- a/exampleSite/static/css/custom.css
+++ b/exampleSite/static/css/custom.css
@@ -1,0 +1,11 @@
+.custom em{
+    color: #a32843
+}
+
+.custom code{
+    color: #ff2f86
+}
+
+.customjs {
+    background-color: #504e9e
+}

--- a/exampleSite/static/js/custom.js
+++ b/exampleSite/static/js/custom.js
@@ -1,0 +1,3 @@
+document.getElementById("customjs").addEventListener("click", function(){
+    this.className += " customjs"
+})

--- a/layouts/partials/layout/javascript.html
+++ b/layouts/partials/layout/javascript.html
@@ -64,3 +64,7 @@
 if (hljs)
   hljs.initHighlightingOnLoad();
 </script>
+{{- $custom_js := $.Param "reveal_hugo.custom_js" -}}
+{{- if $custom_js -}}
+<script type="text/javascript" src="{{ $custom_js | relURL }}"></script>
+{{- end -}}

--- a/layouts/partials/layout/theme.html
+++ b/layouts/partials/layout/theme.html
@@ -21,3 +21,7 @@
   {{- $highlight_theme := $.Param "reveal_hugo.highlight_theme" | default "default" -}}
   <link rel="stylesheet" href="{{ printf "%s/%s.min.css" $highlight_location $highlight_theme | relURL }}">
 {{- end }}
+{{- $custom_css := $.Param "reveal_hugo.custom_css" -}}
+{{- if $custom_css -}}
+<link rel="stylesheet" href="{{ $custom_css | relURL }}" id="custom_css">
+{{- end -}}


### PR DESCRIPTION
As explained in #58 this PR allowes to add a `custom_css` and `custom_js` from configuration.

I tried to add documentation without breaking existing one. Do not hesitate to fix it :)