### PR TITLE
Pipe custom theme asset relURL

### DIFF
--- a/layouts/partials/layout/theme.html
+++ b/layouts/partials/layout/theme.html
@@ -9,7 +9,7 @@
   {{- $custom_theme_options := $.Param "reveal_hugo.custom_theme_options" | default dict -}}
   {{- if $.Param "reveal_hugo.custom_theme_compile" -}}
   {{ $asset := resources.Get $custom_theme | resources.ExecuteAsTemplate "_.scss" . | toCSS $custom_theme_options | minify | fingerprint }}
-  <link rel="stylesheet" href="{{ $asset.Permalink }}" id="theme">
+  <link rel="stylesheet" href="{{ $asset.Permalink | relURL }}" id="theme">
   {{- else -}}
   <link rel="stylesheet" href="{{ $custom_theme | relURL }}" id="theme">
   {{- end -}}


### PR DESCRIPTION
Thanks for this great project!

All href-tags in ` layouts/partials/layout/theme.html` use the `relURL` pipe, except the custom theme asset. This breaks the `relativeURLs` function from Hugo for my use-case. So I propose to make it consistent.