### PR TITLE
Hugo 0.60 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,6 @@ Visit [reveal-hugo.dzello.com](https://reveal-hugo.dzello.com/) to see a present
 
 For a full-length blog post about reveal-hugo, checkout [Harness the Power of Static Site Generators to Create Presentations](https://forestry.io/blog/harness-the-power-of-static-to-create-presentations/) on the [Forestry.io blog](https://forestry.io/blog).
 
-### ⚠️ hugo 0.60 compatibility
-
-reveal-hugo doesn't support Goldmark yet, which is Hugo's default markdown parser as of 0.60. To use reveal-hugo with hugo 0.60+ you can set `markdown.defaultMarkdownHandler` to `"blackfriday"` in `config.toml`.
-
-```toml
-[markup]
-defaultMarkdownHandler = "blackfriday"
-```
-
 ### Demos
 
 Jump to the [exampleSite](exampleSite) folder in this repository to see the source code for the above presentation and several more. Here are links to those presentations live:

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,7 +16,12 @@ name = "Josh Dzielak"
 # reveal-hugo doesn't support goldmark yet
 # so force to black friday
 [markup]
-defaultMarkdownHandler = "blackfriday"
+# defaultMarkdownHandler = "blackfriday"
+[markup.goldmark.renderer]
+unsafe = true
+[markup.highlight]
+# we need a style that looks good in both light and dark background!
+style = "tango"
 
 [outputFormats.Reveal]
 baseName = "index"

--- a/exampleSite/content/home/configuration.md
+++ b/exampleSite/content/home/configuration.md
@@ -41,7 +41,9 @@ custom_theme_compile = true
 ```
 
 <small>
+
 💡 See the [custom theme example presentation](/custom-theme-example/) for more details.
+
 </small>
 
 ---
@@ -54,8 +56,11 @@ reveal-hugo comes with 2 extra Reveal.js themes:
 - [sunblind](https://github.com/dzello/revealjs-themes#sunblind)
 
 <br>
+
 <small>
+
 They live in the `static/reveal-hugo/themes` folder and also [on Github](https://github.com/dzello/revealjs-themes).
+
 </small>
 
 ---
@@ -110,7 +115,9 @@ Here is where to put partials for different presentations and places in the DOM.
 &nbsp;
 
 <small>
+
 💡 You can also create an `end.html` to put content before the end of the `.reveal` div tag.
+
 </small>
 
 ---
@@ -155,7 +162,9 @@ custom_js = "js/custom.js"
 ```
 
 <small>
+
 These files can be located in `static/css`, `static/js` folder 
 
 💡 See the [extending layout example](/extending-layout-example/#) for more details.
+
 </small>

--- a/exampleSite/content/home/features.md
+++ b/exampleSite/content/home/features.md
@@ -9,6 +9,8 @@ weight = 10
 - Two custom Reveal.js themes (including this one)
 
 <br>
+<br>
+
 [see the code on github](https://github.com/dzello/reveal-hugo)
 
 ---

--- a/exampleSite/content/home/shortcodes/slide.md
+++ b/exampleSite/content/home/shortcodes/slide.md
@@ -102,6 +102,7 @@ Add the shortcode above the slide's content, below the `---`.
 ```
 
 <br>
+
 [Try the link](#custom-slide)
 
 ---

--- a/exampleSite/data/common/nested.toml
+++ b/exampleSite/data/common/nested.toml
@@ -12,8 +12,6 @@ example = "I'm a slide"
 Set the `content` attribute to "common.nested.example":
 
 ```markdown
----
-
 {{< slide content="common.nested.example" >}}
 ```
 

--- a/exampleSite/data/home.toml
+++ b/exampleSite/data/home.toml
@@ -1,3 +1,6 @@
+# Note: it seems that under goldmark, markdown in data templates has issues.
+#       In particular "---" is converted to <hr> even inside code fences!
+
 reusable = '''
 
 ## Reusable slides
@@ -23,11 +26,7 @@ example = "I'm a slide"
 Set the `content` attribute to "home.example":
 
 ```markdown
----
-
 {{< slide content="home.example" >}}
-
----
 ```
 
 ---

--- a/layouts/shortcodes/fragment.html
+++ b/layouts/shortcodes/fragment.html
@@ -1,3 +1,5 @@
+{{/* Render .Inner before processing the shortcode. */}}
+{{ $_hugo_config := `{ "version": 1 }` }}
 <span class='fragment {{ .Get "class" }}'
   {{ with .Get "index" }}data-fragment-index='{{ . }}'{{ end }}>
   {{ .Inner }}

--- a/layouts/shortcodes/section.html
+++ b/layouts/shortcodes/section.html
@@ -1,3 +1,5 @@
+{{/* Render .Inner before processing the shortcode. */}}
+{{ $_hugo_config := `{ "version": 1 }` }}
 <section data-shortcode-section>
-{{ .Inner | markdownify }}
+{{ .Inner }}
 </section>


### PR DESCRIPTION
This PR makes reveal-hugo compatible with goldmark.
- Blackfriday still works
- All presentations in `exampleSite` seem to work
- Only weird side effect is that `---` inside a code fence inside a data template fails (I slightly changed the exampleSite to avoid this).
- Note that goldmark uses hugo's highlighter by default in markdown code fences. Luckily we were supporting this already, but we might want to update the docs to reflect this.