### PR TITLE
Monkey-patch fix for fragments inside sections for Hugo 0.60.0+

### DIFF
--- a/layouts/shortcodes/fragment.html
+++ b/layouts/shortcodes/fragment.html
@@ -1,6 +1,4 @@
 {{/* Render .Inner before processing the shortcode. */}}
 {{ $_hugo_config := `{ "version": 1 }` }}
-<span class='fragment {{ .Get "class" }}'
-  {{ with .Get "index" }}data-fragment-index='{{ . }}'{{ end }}>
-  {{ .Inner }}
-</span>
+<span class='fragment {{ .Get "class" }}' {{ with .Get "index" }}data-fragment-index='{{ . }}'{{ end }}>{{ .Inner }}</span>
+


### PR DESCRIPTION
Hacky solution to get fragments working inside section tags for Hugo 0.60.0 and later.  
Seems like Hugo doesn't like the new lines?

* Workaround for https://github.com/dzello/reveal-hugo/issues/93
* Workaround for https://github.com/dzello/reveal-hugo/issues/77
