### PR TITLE
Readme: Install: git clone from ssh to http.

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ If your Hugo site already has a theme but you'd like to create a presentation fr
 
 ```shell
 cd my-hugo-site
-git clone git@github.com:dzello/reveal-hugo.git themes/reveal-hugo
+git clone https://github.com/dzello/reveal-hugo.git themes/reveal-hugo
 cd themes/reveal-hugo
 cp -r layouts static ../../
 ```


### PR DESCRIPTION
Some CI/CD things don't by default, or can't do ssh (sub)modules.
Themes are often used read-only anyway.
Closes #101.