### PR TITLE
Add custom-css-link to html-header

### DIFF
--- a/layouts/partials/reveal-hugo/head.html
+++ b/layouts/partials/reveal-hugo/head.html
@@ -1,1 +1,4 @@
 <!-- override this partial to add content before the head tag closes -->
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}


### PR DESCRIPTION
This way you could use reveal-hugo unchanged and do smaller formatting changes in your hugo slides.
Just add 
```
[params]
custom_css = ["custom.css"]
```
to your configuration and edit `custom.css` in the folder `static/css`.