### PR TITLE
No cdn mermaid

### DIFF
--- a/layouts/partials/layout/javascript.html
+++ b/layouts/partials/layout/javascript.html
@@ -63,11 +63,11 @@
       to the slidechanged event. (mermaid viewBox element has wrong sizes).
       manage hot-reload by using the reveal ready event.
 */}}
-{{ $hasMermaid := true }}
+{{ $hasMermaid := false }}
 {{ range .Site.RegularPages }}
-{{ if .Store.Get "hasMermaid" }}
-  {{ $hasMermaid = true }}
-{{ end }}
+  {{ if .Store.Get "hasMermaid" }}
+    {{ $hasMermaid = true }}
+  {{ end }}
 {{ end }}
 
 {{ if $hasMermaid }}

--- a/layouts/partials/layout/javascript.html
+++ b/layouts/partials/layout/javascript.html
@@ -71,7 +71,8 @@
 {{ end }}
 
 {{ if $hasMermaid }}
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  {{ $mermaidSrc := resources.GetRemote "https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js" }}
+  <script src="{{ $mermaidSrc.RelPermalink }}"></script>
   <script>
     mermaid.initialize({startOnLoad: false});
     let render = (event) => {


### PR DESCRIPTION
Uses build-time mermaid js resource fetch

This removes the need for CDN at each site-load as we download
mermaid js library at hugo build-time. The mermaid script
becomes part of the static site.

Note that, at build time, the mermaid resource is not downloaded if
there are no mermaid blocks in the site.

closes #122
