### PR TITLE
uses .AllPages to evaluate if mermaid is present

### DIFF
--- a/layouts/partials/layout/javascript.html
+++ b/layouts/partials/layout/javascript.html
@@ -64,7 +64,7 @@
       manage hot-reload by using the reveal ready event.
 */}}
 {{ $hasMermaid := false }}
-{{ range .Site.RegularPages }}
+{{ range .Site.AllPages }}
   {{ if .Store.Get "hasMermaid" }}
     {{ $hasMermaid = true }}
   {{ end }}


### PR DESCRIPTION
Simple sites can be solely defined in the root branch bundle _index.md and contain mermaid content, but the mermaid activation iteration was not considering this type of layout.

Using AllPages will iterate on all pages (including translated pages) and properly detect that a root branch bundle has mermaid content.

closes #126 