### PR TITLE
escapes template rendering in usage example

### DIFF
--- a/exampleSite/data/common/nested.toml
+++ b/exampleSite/data/common/nested.toml
@@ -12,7 +12,7 @@ example = "I'm a slide"
 Set the `content` attribute to "common.nested.example":
 
 ```markdown
-{{< slide content="common.nested.example" >}}
+{{</* slide content="common.nested.example" */>}}
 ```
 
 '''

--- a/exampleSite/data/home.toml
+++ b/exampleSite/data/home.toml
@@ -26,7 +26,7 @@ example = "I'm a slide"
 Set the `content` attribute to "home.example":
 
 ```markdown
-{{< slide content="home.example" >}}
+{{</* slide content="home.example" */>}}
 ```
 
 ---


### PR DESCRIPTION
This allows the code to be shown without triggering a template render.

closes #141 