### PR TITLE
Fixes Circle CI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5.0.3
+  go: circleci/go@1.7.2
 
 jobs:
   build-and-test:
@@ -33,5 +34,3 @@ workflows:
   main:
     jobs:
       - build-and-test
-
-# VS Code Extension Version: 1.4.0


### PR DESCRIPTION
This PR fixes #139 (at least I hope so, I cannot test it). As mentioned in #134, adding go to the circleci setup should resolve the builds problems that we currently encounter on the CI server.