### PR TITLE
shortcode highlight must be closed

### DIFF
--- a/exampleSite/content/hugo-hl-example/_index.md
+++ b/exampleSite/content/hugo-hl-example/_index.md
@@ -115,3 +115,5 @@ source = "reveal-js/plugin/zoom-js/zoom.js"
 [[params.reveal_hugo.plugins]]
 name = "RevealNotes"
 source = "reveal-js/plugin/notes/notes.js"
+
+{{< /highlight >}}


### PR DESCRIPTION
`exampleSite` fails because hightlight isn't closed