### PR TITLE
Replace dzello by joshed-io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # reveal-hugo
 
-![License badge](https://img.shields.io/github/license/dzello/reveal-hugo.svg)
-[![CircleCI](https://circleci.com/gh/dzello/reveal-hugo.svg?style=svg)](https://circleci.com/gh/dzello/reveal-hugo)
+![License badge](https://img.shields.io/github/license/joshed-io/reveal-hugo.svg)
+[![CircleCI](https://circleci.com/gh/joshed-io/reveal-hugo.svg?style=svg)](https://circleci.com/gh/joshed-io/reveal-hugo)
 [![Website up/down badge](https://img.shields.io/website-up-down-green-red/https/reveal-hugo.dzello.com.svg)](https://reveal-hugo.dzello.com/)
-![Last commit badge](https://img.shields.io/github/last-commit/dzello/reveal-hugo.svg)
+![Last commit badge](https://img.shields.io/github/last-commit/joshed-io/reveal-hugo.svg)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/70c5c7a6-5fb2-40a9-98e1-20aa21336201/deploy-status)](https://app.netlify.com/sites/reveal-hugo/deploys)
 
 A Hugo theme for [Reveal.js](https://revealjs.com/) that makes authoring and customization a breeze. With it, you can turn any properly-formatted Hugo content into a HTML presentation.
 
-![screenshot of reveal-hugo](https://github.com/dzello/reveal-hugo/blob/master/images/screenshot.png?raw=true)
+![screenshot of reveal-hugo](https://github.com/joshed-io/reveal-hugo/blob/master/images/screenshot.png?raw=true)
 
 ⚠️ The latest version of this theme requires hugo version >= v0.93.0. If you need compatibility with an earlier version, try a previous release.
 
@@ -59,7 +59,7 @@ Jump to the [exampleSite](exampleSite) folder in this repository to see the sour
 
 ### Starter repository
 
-If you want to start creating a presentation right away, clone the [programming-quotes](https://github.com/dzello/programming-quotes) repository and start hacking.
+If you want to start creating a presentation right away, clone the [programming-quotes](https://github.com/joshed-io/programming-quotes) repository and start hacking.
 
 ## Tutorial: Create your first presentation
 
@@ -98,13 +98,13 @@ hugo mod init github.com/me/my-presentation
 - Declare the `reveal-hugo` theme module as a dependency of your site:
 
 ```
-hugo mod get github.com/dzello/reveal-hugo
+hugo mod get github.com/joshed-io/reveal-hugo
 ```
 
 Open `hugo.toml` and add the following line:
 
 ```toml
-theme = ["github.com/dzello/reveal-hugo"]
+theme = ["github.com/joshed-io/reveal-hugo"]
 ```
 
 #### Method 2 (traditional): use theme as git submodule
@@ -112,7 +112,7 @@ theme = ["github.com/dzello/reveal-hugo"]
 Add the `reveal-hugo` theme as a submodule in the themes directory:
 
 ```shell
-git submodule add git@github.com:dzello/reveal-hugo.git themes/reveal-hugo
+git submodule add git@github.com:joshed-io/reveal-hugo.git themes/reveal-hugo
 ```
 
 Open `hugo.toml` and add the following line:
@@ -157,7 +157,7 @@ $ hugo server
 
 Navigate to [http://localhost:1313/](http://localhost:1313/) and you should see your presentation.
 
-![New site with reveal-hugo](https://github.com/dzello/reveal-hugo/blob/master/images/reveal-hugo-hello-world.png?raw=true)
+![New site with reveal-hugo](https://github.com/joshed-io/reveal-hugo/blob/master/images/reveal-hugo-hello-world.png?raw=true)
 
 To add more slides, just add content to `_index.md` or create new markdown files in `content/home`. Remember that each slide must be separated by `---` with blank lines above and below.
 
@@ -194,7 +194,7 @@ cd /path/to/my-presentation
 Then invoke hugo's module `get` subcommand with the update flag `-u`:
 
 ```
-hugo mod get -u github.com/dzello/reveal-hugo
+hugo mod get -u github.com/joshed-io/reveal-hugo
 ```
 
 Hugo will automatically pull in the latest theme version. That's it, your update is done!
@@ -614,13 +614,13 @@ hugo mod init github.com/me/my-presentation
 - Declare the `reveal-hugo` theme module as a dependency of your site:
 
 ```
-hugo mod get github.com/dzello/reveal-hugo
+hugo mod get github.com/joshed-io/reveal-hugo
 ```
 
 Open `hugo.toml`, look for the line `theme = ...` and add `reveal-hugo` to your site's array of themes :
 
 ```toml
-theme = ["your-current-theme", "github.com/dzello/reveal-hugo"]
+theme = ["your-current-theme", "github.com/joshed-io/reveal-hugo"]
 ```
 
 #### Method 2 (traditional): use theme as git submodule
@@ -628,7 +628,7 @@ theme = ["your-current-theme", "github.com/dzello/reveal-hugo"]
 Add the `reveal-hugo` theme as a submodule in the themes directory:
 
 ```shell
-git submodule add git@github.com:dzello/reveal-hugo.git themes/reveal-hugo
+git submodule add git@github.com:joshed-io/reveal-hugo.git themes/reveal-hugo
 ```
 
 Open `hugo.toml`, look for the line `theme = ...` and add `reveal-hugo` to your site's array of themes :
@@ -643,7 +643,7 @@ With hugo < v0.42, you have to manually copy a few files out of this theme into 
 
 ```shell
 cd my-hugo-site
-git clone https://github.com/dzello/reveal-hugo.git themes/reveal-hugo
+git clone https://github.com/joshed-io/reveal-hugo.git themes/reveal-hugo
 cd themes/reveal-hugo
 cp -r layouts static ../../
 ```
@@ -685,7 +685,7 @@ layout = "list"
 
 ### Create a page that lists out all presentations
 
-See [this issue](https://github.com/dzello/reveal-hugo/issues/37) for a template that you can use.
+See [this issue](https://github.com/joshed-io/reveal-hugo/issues/37) for a template that you can use.
 
 ## Reveal.js tips
 
@@ -698,7 +698,7 @@ These are some useful Reveal.js features and shortcuts.
 Here are a few useful Reveal.js-related tools:
 
 - [decktape](https://github.com/astefanutti/decktape) for exporting a presentation as a PDF
-- More [revealjs themes](https://github.com/dzello/revealjs-themes) including robot-lung and sunblind
+- More [revealjs themes](https://github.com/joshed-io/revealjs-themes) including robot-lung and sunblind
 
 Find many more on the Reveal.js wiki: [Plugins, tools and hardware](https://github.com/hakimel/reveal.js/wiki/Plugins,-Tools-and-Hardware).
 
@@ -708,6 +708,7 @@ Have you built something with reveal-hugo? Add a link to it here.
 
 - [dzello's Paris Wedding Weekend Guide](https://estelle.and.dzello.com/guide/) ([source](https://github.com/dzello/estelle-and-josh/blob/master/site/content/guide/_index.md))
 - [DevOps Training](https://devops.training.barpilot.io/) ([source](https://github.com/guilhem/devops-training))
+- [Personal CV](https://www.pablomarcos.me/es/presentations/mi-cv/#/), [Master Thesis](https://www.pablomarcos.me/es/presentations/cangraph/#/), [Master Thesis Update for the WHO](https://www.pablomarcos.me/es/presentations/cangraph-update/) & [Proposal for New Bus Services in Madrid](https://www.pablomarcos.me/es/presentations/alegaciones-crtm/#/) by Pablo Marcos
 
 
 ## Changelog

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://example.com/"
 languageCode = "en-us"
 title = "A Hugo theme for creating Reveal.js presentations"
 disableKinds = ["sitemap", "RSS"]
-theme = "github.com/dzello/reveal-hugo"
+theme = "github.com/joshed-io/reveal-hugo"
 # theme = "."
 # themesDir = "../"
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,8 +10,8 @@ theme = "github.com/joshed-io/reveal-hugo"
 # relativeURLs = true
 # uglyURLs = true
 
-[author]
-name = "Josh Dzielak"
+[params]
+author = "Josh Dzielak"
 
 # currently only the unsafe mode for goldmark is supported
 [markup.goldmark.renderer]

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -19,4 +19,4 @@ background = "#FF4081"
 
 A Hugo theme for creating Reveal.js presentations.
 
-~ made by [@dzello](https://dzello.com/) ~
+~ made by [@dzello](https://joshed.io/) ~

--- a/exampleSite/content/highlightjs-linenumbers-example/_index.md
+++ b/exampleSite/content/highlightjs-linenumbers-example/_index.md
@@ -131,7 +131,7 @@ func main() {
 ## Hiding the line numbers
 
 There is no Reveal.js parameter to use line highlighting *without* line numbers.
-However it can be achieved by adding the some [custom CSS](https://github.com/dzello/reveal-hugo#adding-html-to-the-layout).
+However it can be achieved by adding the some [custom CSS](https://github.com/joshed-io/reveal-hugo#adding-html-to-the-layout).
 
 {{< highlight html "style=github" >}}
 <style>

--- a/exampleSite/content/home/configuration.md
+++ b/exampleSite/content/home/configuration.md
@@ -53,14 +53,14 @@ custom_theme_compile = true
 
 reveal-hugo comes with 2 extra Reveal.js themes:
 
-- [robot-lung](https://github.com/dzello/revealjs-themes#robot-lung) (this one)
-- [sunblind](https://github.com/dzello/revealjs-themes#sunblind)
+- [robot-lung](https://github.com/joshed-io/revealjs-themes#robot-lung) (this one)
+- [sunblind](https://github.com/joshed-io/revealjs-themes#sunblind)
 
 <br>
 
 <small>
 
-They live in the `static/reveal-hugo/themes` folder and also [on Github](https://github.com/dzello/revealjs-themes).
+They live in the `static/reveal-hugo/themes` folder and also [on Github](https://github.com/joshed-io/revealjs-themes).
 
 </small>
 

--- a/exampleSite/content/home/features.md
+++ b/exampleSite/content/home/features.md
@@ -12,7 +12,7 @@ weight = 10
 <br>
 <br>
 
-[see the code on github](https://github.com/dzello/reveal-hugo)
+[see the code on github](https://github.com/joshed-io/reveal-hugo)
 
 ---
 {{< slide id=features >}}

--- a/exampleSite/content/home/resources.md
+++ b/exampleSite/content/home/resources.md
@@ -8,8 +8,8 @@ weight = 42
 
 ## Code and docs
 
-- [reveal-hugo Github README](https://github.com/dzello/reveal-hugo)
-- [Content for this presentation](https://github.com/dzello/reveal-hugo/tree/master/exampleSite)
+- [reveal-hugo Github README](https://github.com/joshed-io/reveal-hugo)
+- [Content for this presentation](https://github.com/joshed-io/reveal-hugo/tree/master/exampleSite)
 
 ---
 

--- a/exampleSite/content/logo-example/_index.md
+++ b/exampleSite/content/logo-example/_index.md
@@ -16,7 +16,7 @@ You can generalize the concept to add any additional markup to your presentation
 
 ---
 
-[See the code for this presentation](https://github.com/dzello/reveal-hugo/blob/master/exampleSite/content/logo-example)
+[See the code for this presentation](https://github.com/joshed-io/reveal-hugo/blob/master/exampleSite/content/logo-example)
 
 ---
 

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,7 +1,7 @@
-module github.com/dzello/reveal-hugo/exampleSite
+module github.com/joshed-io/reveal-hugo/exampleSite
 
 go 1.12
 
-require github.com/dzello/reveal-hugo v0.0.0-20221228063604-4c190e12065e // indirect
+require github.com/joshed-io/reveal-hugo v0.0.0-20221228063604-4c190e12065e // indirect
 
-replace github.com/dzello/reveal-hugo => ../
+replace github.com/joshed-io/reveal-hugo => ../

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,4 +1,4 @@
-github.com/dzello/reveal-hugo v0.0.0-20220224002855-eae99411d91a h1:qHXMoi8lo+F2w0ZFnsKTx5ov7Tkl/TjmGmmRb3POMH0=
-github.com/dzello/reveal-hugo v0.0.0-20220224002855-eae99411d91a/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
-github.com/dzello/reveal-hugo v0.0.0-20221228063604-4c190e12065e h1:LQvRSfgRghe5G1hfIAgWA4HTSOWe7WysTp/j1PiNdwg=
-github.com/dzello/reveal-hugo v0.0.0-20221228063604-4c190e12065e/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
+github.com/joshed-io/reveal-hugo v0.0.0-20220224002855-eae99411d91a h1:qHXMoi8lo+F2w0ZFnsKTx5ov7Tkl/TjmGmmRb3POMH0=
+github.com/joshed-io/reveal-hugo v0.0.0-20220224002855-eae99411d91a/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=
+github.com/joshed-io/reveal-hugo v0.0.0-20221228063604-4c190e12065e h1:LQvRSfgRghe5G1hfIAgWA4HTSOWe7WysTp/j1PiNdwg=
+github.com/joshed-io/reveal-hugo v0.0.0-20221228063604-4c190e12065e/go.mod h1:0S5eDEdHBx8tSj8veo9lUnuJRXa8WqmpANd0Lz7CLc8=

--- a/exampleSite/static/reveal-hugo/themes/robot-lung.css
+++ b/exampleSite/static/reveal-hugo/themes/robot-lung.css
@@ -3,7 +3,7 @@
   [ robot-lung ]
 
   A hot pink theme for Reveal.js with Roboto fonts and a colorful border.
-  By Josh Dzielak, https://dzello.com/, License MIT
+  By Josh Dzielak, https://joshed.io/, License MIT
 
   The bold border is optional and requires some HTML. To use it:
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dzello/reveal-hugo
+module github.com/joshed-io/reveal-hugo
 
 go 1.12

--- a/static/reveal-hugo/themes/robot-lung.css
+++ b/static/reveal-hugo/themes/robot-lung.css
@@ -3,7 +3,7 @@
   [ robot-lung ]
 
   A hot pink theme for Reveal.js with Roboto fonts and a colorful border.
-  By Josh Dzielak, https://dzello.com/, License MIT
+  By Josh Dzielak, https://joshed.io/, License MIT
 
   The bold border is optional and requires some HTML. To use it:
 

--- a/static/reveal-hugo/themes/sunblind.css
+++ b/static/reveal-hugo/themes/sunblind.css
@@ -3,7 +3,7 @@
   [ sunblind ]
 
   A blindingly sunny theme for Reveal.js with Lora + Leto fonts and a colorful border.
-  By Josh Dzielak, https://dzello.com/, License MIT
+  By Josh Dzielak, https://joshed.io/, License MIT
 
   The bold border is optional and requires some HTML. To use it:
 

--- a/theme.toml
+++ b/theme.toml
@@ -1,13 +1,13 @@
 name = "reveal-hugo"
 license = "MIT"
-licenselink = "https://github.com/dzello/reveal-hugo/blob/master/LICENSE"
+licenselink = "https://github.com/joshed-io/reveal-hugo/blob/master/LICENSE"
 homepage = "https://reveal-hugo.dzello.com/"
 tags = ["presentation", "revealjs"]
 features = ["presentation"]
 
 [author]
 name = "Josh Dzielak"
-homepage = "https://dzello.com/"
+homepage = "https://joshed.io/"
 
 [original]
 name = "reveal.js"


### PR DESCRIPTION
 ## What is this PR supposed to accomplish?

The theme cannot be updated, since its url is now `joshed-io/reveal-hugo`, but its go.mod points to `dzello/reveal-hugo`. By updating URLs, it should be possible to update the theme.

## Change log

- Replaced github.com/dzello by github.com/joshed-io
- Left dzello.com mentions unchanged, unless they refered to the full website

## Tests

```
pablo@hp-pablo:~/Descargas/reveal-hugo$ hugo server -s exampleSite
port 1313 already in use, attempting to use an available port
Watching for changes in /home/pablo/Descargas/reveal-hugo/{assets,exampleSite,layouts,package.json,static}
Watching for config changes in /home/pablo/Descargas/reveal-hugo/exampleSite/config.toml, /home/pablo/Descargas/reveal-hugo/exampleSite/go.mod
Start building sites … 
hugo v0.136.5-46cccb021bc6425455f4eec093f5cc4a32f1d12c+extended linux/amd64 BuildDate=2024-10-24T12:26:27Z VendorInfo=snap:0.136.5


                   | EN   
-------------------+------
  Pages            |  11  
  Paginator pages  |   0  
  Non-page files   |   4  
  Static files     | 168  
  Processed images |   0  
  Aliases          |   0  
  Cleaned          |   0  

Built in 208 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:37871/ (bind address 127.0.0.1) 
Press Ctrl+C to stop
```