### PR TITLE
change author parameter location because of Hugo updates

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,7 +11,9 @@ theme = "github.com/joshed-io/reveal-hugo"
 # uglyURLs = true
 
 [params]
-author = "Josh Dzielak"
+
+[author]
+  name = "Josh Dzielak"
 
 # currently only the unsafe mode for goldmark is supported
 [markup.goldmark.renderer]

--- a/layouts/partials/layout/head.html
+++ b/layouts/partials/layout/head.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <title>{{ or .Page.Title .Site.Title }}</title>
 {{ with $.Param "description" }}<meta name="description" content="{{ . }}">{{ end }}
-{{ with .Site.Author.name }}<meta name="author" content="{{ . }}">{{ end }}
+{{ with .Site.Params.Author.name }}<meta name="author" content="{{ . }}">{{ end }}
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
Applies [Hugo release 0.156.0 changes](https://github.com/gohugoio/hugo/releases/tag/v0.156.0) from Feb 18, 2026:
- `.Site.Author` (use `.Site.Params.Author`)

Otherwise all sites break with error:
```
ERROR error building site: render: [en v1.0.0 guest] failed to render pages: render of "[...]/reveal-hugo/exampleSite/content/hugo-hl-example/_index.md" failed: "[...]/reveal-hugo/layouts/_default/baseof.reveal.html:4:7": execute of template failed: template: list.reveal.html:4:7: executing "list.reveal.html" at <partial "layout/head" .>: error calling partial: "[...]/reveal-hugo/layouts/partials/layout/head.html:4:13": execute of template failed: template: _partials/layout/head.html:4:13: executing "_partials/layout/head.html" at <.Site.Params.Author.name>: can't evaluate field name in type string
```